### PR TITLE
docs: Add instructions for running server with uvx

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -80,6 +80,20 @@ To publish the package to PyPI:
    pip install perplexica-mcp
    ```
 
+## Running with uvx
+
+This server can also be run directly using `uvx`, which is part of the `uv` (astral-uv) Python package manager. This method assumes that `uv` is installed and the `perplexica-mcp` package has been published to PyPI by the user/organization `armand0e`.
+
+To run the server using `uvx`, use the following command:
+
+```bash
+uvx @armand0e/perplexica-mcp:latest
+```
+
+`uvx` will handle the download of the package and its dependencies into a managed environment and then execute the server. This is a convenient way to run the server without a manual installation step.
+
+Ensure that the package `perplexica-mcp` is published on PyPI under the `armand0e` user or organization for this command to work.
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
This commit updates DEPLOYMENT.md to include a new section on how to run the perplexica-mcp server using the `uvx` command.

The new instructions specify:
- The command `uvx @armand0e/perplexica-mcp:latest`.
- The prerequisite that `uv` (astral-uv) must be installed.
- The assumption that the `perplexica-mcp` package is published on PyPI by the user/organization `armand0e`.

This provides an alternative method for you to run the server, leveraging `uvx` for environment and dependency management. No code changes were required as the existing packaging and entry points are compatible with this execution method.